### PR TITLE
fix: docker-compose

### DIFF
--- a/app/components/Research/ElasticResearch.js
+++ b/app/components/Research/ElasticResearch.js
@@ -8,8 +8,11 @@ import ListElastic from "./ListElastic";
 import { GET_LIST_ARTICLES_QUERY } from "./queries";
 import { useQuery } from "@apollo/react-hooks";
 
-//const ELASTIC_URL = "http://40.89.168.163:9210"; // Only work with URI can't use /elastic
-const ELASTIC_URL = typeof window !== 'undefined' ? window.location.origin + "/elastic":""
+// proxified by express server. full absolute URL needed here
+const ELASTIC_URL =
+  typeof window !== "undefined"
+    ? window.location.origin + "/elastic"
+    : process.env.ELASTIC_URL;
 
 //http://localhost:9200/"; // Docker networking
 

--- a/app/components/Research/ElasticResearch.js
+++ b/app/components/Research/ElasticResearch.js
@@ -8,8 +8,10 @@ import ListElastic from "./ListElastic";
 import { GET_LIST_ARTICLES_QUERY } from "./queries";
 import { useQuery } from "@apollo/react-hooks";
 
-const ELASTIC_URL = "http://40.89.168.163:9210"; // Only work with URI can't use /elastic
-//const ELASTIC_URL = "http://localhost:9200/"; // Docker networking
+//const ELASTIC_URL = "http://40.89.168.163:9210"; // Only work with URI can't use /elastic
+const ELASTIC_URL = typeof window !== 'undefined' ? window.location.origin + "/elastic":""
+
+//http://localhost:9200/"; // Docker networking
 
 function queryElastic(value, moderatedArticles) {
   return {

--- a/app/config/config.js
+++ b/app/config/config.js
@@ -1,8 +1,7 @@
-// export const GRAPHQL_URL = "/graphql-engine/v1/graphql" / can't use absolute path
-// export const GRAPHQL_URL = "http://localhost:8080/v1/graphql"; // for local use only
-
-export const GRAPHQL_URL = "/graphql-engine"
-///v1/graphql"; // with docker Networking
-//export const GRAPHQL_URL = "//40.89.168.163:8082/v1/graphql";
+// proxified by express server
+export const GRAPHQL_URL =
+  typeof window !== "undefined"
+    ? window.location.origin + "/graphql-engine/v1/graphql"
+    : process.env.GRAPHQL_URL;
 
 export const PER_PAGE = 5;

--- a/app/config/config.js
+++ b/app/config/config.js
@@ -1,7 +1,8 @@
 // export const GRAPHQL_URL = "/graphql-engine/v1/graphql" / can't use absolute path
 // export const GRAPHQL_URL = "http://localhost:8080/v1/graphql"; // for local use only
 
-export const GRAPHQL_URL = "http://localhost:8080/v1/graphql"; // with docker Networking
+export const GRAPHQL_URL = "/graphql-engine"
+///v1/graphql"; // with docker Networking
 //export const GRAPHQL_URL = "//40.89.168.163:8082/v1/graphql";
 
 export const PER_PAGE = 5;

--- a/app/server.js
+++ b/app/server.js
@@ -3,8 +3,8 @@ const express = require("express");
 const next = require("next");
 const proxyMiddleware = require("http-proxy-middleware");
 
-const ELASTIC_URL = process.env.ELASTIC_URL || "http://127.0.0.1:9200";
-const GRAPHQL_URL = process.env.GRAPHQL_URL || "http://127.0.0.1:8080";
+const ELASTIC_URL = process.env.ELASTIC_URL || "http://127.0.0.1:9210";
+const GRAPHQL_URL = process.env.GRAPHQL_URL || "http://127.0.0.1:8082";
 const PORT = parseInt(process.env.PORT, 10) || 3000;
 const NODE_ENV = process.env.NODE_ENV;
 
@@ -20,7 +20,6 @@ const proxies = {
     changeOrigin: true
   }
 };
-
 
 const dev = NODE_ENV !== "production";
 const app = next({

--- a/docker-compose.override.prod.yaml
+++ b/docker-compose.override.prod.yaml
@@ -13,6 +13,4 @@ services:
       ELASTIC_URL: http://elastic:9200
       GRAPHQL_URL: http://graphql-engine:8080/v1/graphql
     ports:
-      - 3030:3000
-    networks:
-      - textStyleNetwork
+      - 80:3000

--- a/docker-compose.override.prod.yaml
+++ b/docker-compose.override.prod.yaml
@@ -1,4 +1,4 @@
-version: '3.6'
+version: '3.3'
 services:
   app:
     build:
@@ -11,6 +11,6 @@ services:
         MATOMO_SITE_ID: 42
     environment:
       ELASTIC_URL: http://elastic:9200
-      GRAPHQL_URL: http://graphql-engine:8080/v1/graphql
+      GRAPHQL_URL: http://graphql-engine:8080
     ports:
       - 80:3000

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,8 +11,6 @@ services:
       memlock:
         soft: -1
         hard: -1
-    networks:
-      - textStyleNetwork
   postgres:
     image: postgres
     restart: always
@@ -20,17 +18,12 @@ services:
       - db_data:/var/lib/postgresql/data
     ports:
       - 5434:5432
-    networks:
-      - textStyleNetwork
   graphql-engine:
     image: hasura/graphql-engine:v1.0.0-beta.6
     ports:
     - "8082:8080"
     depends_on:
     - "postgres"
-    restart: always
-    networks:
-      - textStyleNetwork
     environment:
       HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:@postgres:5432/postgres
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true" # set to "false" to disable console
@@ -40,5 +33,3 @@ services:
 volumes:
   db_data:
   es_data:
-networks:
-      textStyleNetwork:


### PR DESCRIPTION

 - use express to proxify graphql-engine and elastic
 - use absolute urls
 - use exotic ports to prevent clash with local instances